### PR TITLE
kafkacat 1.6.0

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 pkgname=kafkacat
-pkgver=1.5.0
+pkgver=1.6.0
 pkgrel=0
 pkgdesc="Generic command line non-JVM Apache Kafka producer and consumer"
 url="https://github.com/edenhill/kafkacat"
@@ -42,4 +42,4 @@ doc() {
 	default_doc
 }
 
-sha512sums="57f75b26ef32df244043fa9fc17dc2d6fd93daeea4bc389aa78356ea6e45dea780ff9c3462ed27d2a7798560a21eef04f098bf7766c7305bcee4573f557651ad  kafkacat-1.5.0.tar.gz"
+sha512sums="a203f3db21fef7b885d5b394458541c830078ae3fe4c8d2d59226db14db6ef470e167bd9491982751086cd96837ff10699709e4379d007857a4058335207e858  kafkacat-1.6.0.tar.gz"


### PR DESCRIPTION
💁 Updates the version of `kafkacat` to [1.6.0](https://github.com/edenhill/kafkacat/releases/tag/1.6.0).