### PR TITLE
Update release version to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current installation method for these packages is to pull them in using
 
     apk --no-cache add ca-certificates wget
     wget --quiet --output-document=/etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-kafkacat/releases/download/1.5.0-r0/kafkacat-1.5.0-r0.apk
-    apk add --no-cache kafkacat-1.5.0-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-kafkacat/releases/download/1.6.0-r0/kafkacat-1.6.0-r0.apk
+    apk add --no-cache kafkacat-1.6.0-r0.apk
 
 [kafkacat]: https://github.com/edenhill/kafkacat


### PR DESCRIPTION
💁 In preparation for a new tag to be released, update the installation documentation to the new version.