### PR TITLE
Rename upstream project to kcat

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -12,8 +12,8 @@ depends_dev=""
 makedepends="$depends_dev bash librdkafka-dev musl-dev yajl-dev zlib-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"
-source="kafkacat-$pkgver.tar.gz::https://github.com/edenhill/kafkacat/archive/$pkgver.tar.gz"
-builddir="$srcdir/kafkacat-$pkgver"
+source="kcat-$pkgver.tar.gz::https://github.com/edenhill/kcat/archive/$pkgver.tar.gz"
+builddir="$srcdir/kcat-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -42,4 +42,4 @@ doc() {
 	default_doc
 }
 
-sha512sums="a203f3db21fef7b885d5b394458541c830078ae3fe4c8d2d59226db14db6ef470e167bd9491982751086cd96837ff10699709e4379d007857a4058335207e858  kafkacat-1.6.0.tar.gz"
+sha512sums="3d92666e61d8fca52be985c87b984c2b50ef6eabf3dce37b551d6f9988582dc22d5d3a18ac8932905d131af9ccfa38e886eefeed5a71ae828f5c4e0c77adf2d5  kcat-1.6.0.tar.gz"


### PR DESCRIPTION
💁 The upstream project was renamed to kcat in https://github.com/edenhill/kcat/pull/339